### PR TITLE
BREAKING: Update to `tokio` 0.2

### DIFF
--- a/bigml-parallel/Cargo.toml
+++ b/bigml-parallel/Cargo.toml
@@ -15,16 +15,17 @@ cli_test_dir = "0.1.5"
 
 [dependencies]
 bigml = { version = "=0.4.4", path = "../bigml" }
-bytes = "0.4.12"
+bytes = "0.5.3"
 common_failures = "0.1.1"
 # This makes the executable bigger, but it makes --help much nicer.
 clap = { version = "2", features = ["wrap_help"] }
 env_logger = "0.7"
 failure = "0.1.5"
-futures-preview = { version = "0.3.0-alpha.17", features = ["compat"] }
+futures = "0.3.1"
 log = "0.4"
 serde = { version = "1" }
 serde_json = "1.0"
 # This is pretty heavyweight, but it's easy to set up and nice for users.
 structopt = "0.3.4"
-tokio = "0.1.22"
+tokio = { version = "0.2.6", features = ["fs", "io-std", "stream"] }
+tokio-util = { version = "0.2.0", features = ["codec"] }

--- a/bigml-parallel/Cargo.toml
+++ b/bigml-parallel/Cargo.toml
@@ -27,5 +27,5 @@ serde = { version = "1" }
 serde_json = "1.0"
 # This is pretty heavyweight, but it's easy to set up and nice for users.
 structopt = "0.3.4"
-tokio = { version = "0.2.6", features = ["fs", "io-std", "stream"] }
+tokio = { version = "0.2.6", features = ["fs", "io-std"] }
 tokio-util = { version = "0.2.0", features = ["codec"] }

--- a/bigml-parallel/src/line_delimited_json_codec.rs
+++ b/bigml-parallel/src/line_delimited_json_codec.rs
@@ -4,7 +4,7 @@ use bytes::{BufMut, BytesMut};
 use failure::Error;
 use serde::Serialize;
 use std::marker::PhantomData;
-use tokio::codec::Encoder;
+use tokio_util::codec::Encoder;
 
 /// A [`tokio::codec::Encoder`] that outputs a [line-delimited JSON
 /// stream][json]. This can be used to output a `Stream` of values implementing
@@ -31,7 +31,7 @@ impl<T: Serialize> Encoder for LineDelimitedJsonCodec<T> {
     fn encode(&mut self, item: T, buf: &mut BytesMut) -> Result<(), Error> {
         let json = serde_json::to_vec(&item)?;
         buf.reserve(json.len() + 1);
-        buf.put(json);
+        buf.put(&json[..]);
         buf.put_u8(b'\n');
         Ok(())
     }

--- a/bigml-parallel/tests/tests.rs
+++ b/bigml-parallel/tests/tests.rs
@@ -6,7 +6,7 @@ use bigml::{
 };
 use cli_test_dir::*;
 use common_failures::prelude::*;
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use serde_json;
 use std::{env, future::Future, io::Write};
 use tokio::runtime::Runtime;
@@ -26,7 +26,7 @@ where
     T: Send + 'static,
 {
     let mut runtime = Runtime::new().expect("Unable to create a runtime");
-    runtime.block_on(fut.boxed().compat())
+    runtime.block_on(fut.boxed())
 }
 
 #[test]

--- a/bigml/Cargo.toml
+++ b/bigml/Cargo.toml
@@ -16,17 +16,16 @@ env_logger = "0.7"
 
 [dependencies]
 bigml_derive = { version = "0.2.2", path = "../bigml_derive" }
-bytes = "0.4.12"
+bytes = "0.5.3"
 chrono = { version = "0.4", features = ["serde"] }
 failure = "0.1.1"
-futures-preview = { version = "0.3.0-alpha.17", features = ["compat"] }
+futures = "0.3.1"
 lazy_static = "1.3"
 log = "0.4"
 mime = "0.3"
-mpart-async = "0.2.1"
-reqwest = "0.9"
+reqwest = { version = "0.10", features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-tokio = "0.1.22"
-tokio-timer = "0.1"
-url = "1.2"
+tokio = { version = "0.2.6", features = ["fs", "macros"] }
+tokio-util = { version = "0.2.0", features = ["codec"] }
+url = "2.1"

--- a/bigml/examples/create_execution.rs
+++ b/bigml/examples/create_execution.rs
@@ -1,20 +1,22 @@
 use bigml;
 use env_logger;
 use failure;
+use futures::executor::block_on;
 #[macro_use]
 extern crate log;
 
 use bigml::resource;
-use failure::ResultExt;
-use futures::{FutureExt, TryFutureExt};
-use std::env;
-use std::io::{self, Write};
-use std::process;
-use std::result;
-use std::str::FromStr;
-use tokio::prelude::*;
+use failure::{Error, ResultExt};
+use futures::FutureExt;
+use std::{
+    env,
+    io::{self, Write},
+    process, result,
+    str::FromStr,
+};
 
-type Result<T> = result::Result<T, failure::Error>;
+/// A custom `Result`, for convenience.
+pub type Result<T, E = Error> = result::Result<T, E>;
 
 /// A local helper function which does the real work, and which can return
 /// an error (unlike `main`).
@@ -43,7 +45,7 @@ fn helper(
     }
 
     // Execute the script, wait for it to complete, and print the result.
-    let execution = client.create_and_wait(&args).boxed().compat().wait()?;
+    let execution = block_on(client.create_and_wait(&args).boxed())?;
     println!("{:#?}", execution);
 
     Ok(())

--- a/bigml/examples/create_source.rs
+++ b/bigml/examples/create_source.rs
@@ -2,16 +2,14 @@
 // `create_source_from_path`.
 #![allow(deprecated)]
 
-use bigml;
+use bigml::{self, resource::Resource};
 use env_logger;
 
-use bigml::resource::Resource;
-use futures::{FutureExt, TryFutureExt};
+use futures::{executor::block_on, FutureExt};
 use std::env;
 use std::io::{self, Write};
 use std::path::Path;
 use std::process;
-use tokio::prelude::*;
 
 fn main() {
     env_logger::init();
@@ -31,17 +29,9 @@ fn main() {
 
     let client = bigml::Client::new(bigml_username, bigml_api_key)
         .expect("can't create bigml::Client");
-    let initial_response = client
-        .create_source_from_path(&path)
-        .boxed()
-        .compat()
-        .wait()
+    let initial_response = block_on(client.create_source_from_path(path).boxed())
         .expect("can't create source");
-    let response = client
-        .wait(initial_response.id())
-        .boxed()
-        .compat()
-        .wait()
+    let response = block_on(client.wait(initial_response.id()).boxed())
         .expect("error waiting for resource");
 
     println!("{:#?}", &response);

--- a/bigml/src/client.rs
+++ b/bigml/src/client.rs
@@ -130,7 +130,7 @@ impl Client {
     #[allow(clippy::needless_lifetimes, deprecated)]
     #[deprecated = "This won't work until BigML fixes Transfer-Encoding: chunked"]
     pub async fn create_source_from_path(&self, path: PathBuf) -> Result<Source> {
-        // Covnert our path to a stream of `Bytes`.
+        // Convert our path to a stream of `Bytes`.
         let file = fs::File::open(&path)
             .await
             .map_err(|err| Error::could_not_read_file(&path, err))?;

--- a/bigml/src/errors.rs
+++ b/bigml/src/errors.rs
@@ -14,7 +14,7 @@ use std::result;
 use url::Url;
 
 /// A custom `Result`, for convenience.
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T, E = Error> = result::Result<T, E>;
 
 /// A BigML-related error.
 #[derive(Debug, Fail)]
@@ -114,6 +114,17 @@ impl Error {
     {
         Error::CouldNotGetOutput {
             name: name.to_owned(),
+            error: error.into(),
+        }
+    }
+
+    pub(crate) fn could_not_read_file<P, E>(path: P, error: E) -> Error
+    where
+        P: Into<PathBuf>,
+        E: Into<failure::Error>,
+    {
+        Error::CouldNotReadFile {
+            path: path.into(),
             error: error.into(),
         }
     }

--- a/bigml/src/lib.rs
+++ b/bigml/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ```no_run(
 //! use bigml::{Client, resource::{execution, Id, Script}};
-//! use futures::{FutureExt, TryFutureExt};
+//! use futures::{executor::block_on, FutureExt, TryFutureExt};
 //! use std::{path::Path, str::FromStr};
 //! use tokio::prelude::*;
 //!
@@ -23,11 +23,9 @@
 //! // Create a BigML client.
 //! let client = bigml::Client::new(username, api_key)?;
 //!
-//! // Create a source.
-//! let source = client.create_source_from_path_and_wait(path)
-//!   .boxed()
-//!   .compat()
-//!   .wait()?;
+//! // Create a source (actually, you should do this via S3 for now).
+//! let source =
+//!     block_on(client.create_source_from_path_and_wait(path.to_owned()))?;
 //! println!("{:?}", source);
 //!
 //! // Execute the script.
@@ -35,10 +33,7 @@
 //! args.set_script(script_id);
 //! args.add_input("source-id", &source.resource)?;
 //! args.add_output("my-output");
-//! let execution = client.create_and_wait(&args)
-//!   .boxed()
-//!   .compat()
-//!   .wait()?;
+//! let execution = block_on(client.create_and_wait(&args))?;
 //! println!("{:?}", execution);
 //! #
 //! #   Ok(())

--- a/bigml/src/resource/execution/args.rs
+++ b/bigml/src/resource/execution/args.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json;
 use std::error;
 use std::fmt;
-use std::result;
 
 use super::Execution;
 use crate::errors::*;
@@ -109,7 +108,7 @@ impl Output {
         if let Some(ref value) = self.value {
             // We need to be explicit about the error type we want
             // `from_value` to return here.
-            let result: result::Result<D, serde_json::error::Error> =
+            let result: Result<D, serde_json::error::Error> =
                 serde_json::value::from_value(value.to_owned());
             result.map_err(|e| Error::could_not_get_output(&self.name, e))
         } else {
@@ -122,7 +121,7 @@ impl Output {
 }
 
 impl<'de> Deserialize<'de> for Output {
-    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -137,7 +136,7 @@ impl<'de> Deserialize<'de> for Output {
                 write!(f, "either a string or a [name, value, type] sequence")
             }
 
-            fn visit_str<E>(self, v: &str) -> result::Result<Self::Value, E>
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
                 E: error::Error,
             {
@@ -149,10 +148,7 @@ impl<'de> Deserialize<'de> for Output {
                 })
             }
 
-            fn visit_seq<V>(
-                self,
-                mut visitor: V,
-            ) -> result::Result<Self::Value, V::Error>
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
             where
                 V: de::SeqAccess<'de>,
             {
@@ -230,7 +226,7 @@ fn deserialize_multiple_outputs() {
 }
 
 impl Serialize for Output {
-    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -284,7 +280,7 @@ pub struct LogEntry {
 }
 
 impl<'de> Deserialize<'de> for LogEntry {
-    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -299,10 +295,7 @@ impl<'de> Deserialize<'de> for LogEntry {
                 write!(f, "a list containing log entry information")
             }
 
-            fn visit_seq<V>(
-                self,
-                mut visitor: V,
-            ) -> result::Result<Self::Value, V::Error>
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
             where
                 V: de::SeqAccess<'de>,
             {
@@ -340,7 +333,7 @@ impl<'de> Deserialize<'de> for LogEntry {
 }
 
 impl Serialize for LogEntry {
-    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/bigml/src/resource/execution/execution_status.rs
+++ b/bigml/src/resource/execution/execution_status.rs
@@ -86,13 +86,12 @@ impl Status for ExecutionStatus {
 /// Functions for (de)serializing WhizzML call stacks.
 pub(crate) mod call_stack_repr {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use std::result;
 
     use super::*;
 
     pub(crate) fn deserialize<'de, D>(
         deserializer: D,
-    ) -> result::Result<Option<Vec<SourceLocation>>, D::Error>
+    ) -> Result<Option<Vec<SourceLocation>>, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -114,7 +113,7 @@ pub(crate) mod call_stack_repr {
     pub(crate) fn serialize<S>(
         stack: &Option<Vec<SourceLocation>>,
         serializer: S,
-    ) -> result::Result<S::Ok, S::Error>
+    ) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/bigml/src/resource/execution/mod.rs
+++ b/bigml/src/resource/execution/mod.rs
@@ -6,7 +6,6 @@ use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json;
 use std::fmt;
-use std::result;
 use url::Url;
 
 use super::id::*;
@@ -101,7 +100,7 @@ pub struct Source {
 }
 
 impl<'de> Deserialize<'de> for Source {
-    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -116,10 +115,7 @@ impl<'de> Deserialize<'de> for Source {
                 write!(f, "a list with a source ID and a description")
             }
 
-            fn visit_seq<V>(
-                self,
-                mut visitor: V,
-            ) -> result::Result<Self::Value, V::Error>
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
             where
                 V: de::SeqAccess<'de>,
             {
@@ -145,7 +141,7 @@ impl<'de> Deserialize<'de> for Source {
 }
 
 impl Serialize for Source {
-    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -193,7 +189,7 @@ impl fmt::Display for SourceId {
 }
 
 impl<'de> Deserialize<'de> for SourceId {
-    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -208,7 +204,7 @@ impl<'de> Deserialize<'de> for SourceId {
                 write!(f, "a script or library ID")
             }
 
-            fn visit_str<E>(self, value: &str) -> result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where
                 E: de::Error,
             {
@@ -233,7 +229,7 @@ impl<'de> Deserialize<'de> for SourceId {
 }
 
 impl Serialize for SourceId {
-    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/bigml/src/resource/id.rs
+++ b/bigml/src/resource/id.rs
@@ -4,7 +4,6 @@ use serde::de::Unexpected;
 use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::marker::PhantomData;
-use std::result;
 use std::str::FromStr;
 use url::Url;
 
@@ -68,7 +67,7 @@ impl<R: Resource> fmt::Display for Id<R> {
 }
 
 impl<'de, R: Resource> Deserialize<'de> for Id<R> {
-    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -91,7 +90,7 @@ impl<'de, R: Resource> Deserialize<'de> for Id<R> {
 }
 
 impl<R: Resource> Serialize for Id<R> {
-    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/bigml/src/resource/status.rs
+++ b/bigml/src/resource/status.rs
@@ -2,7 +2,6 @@
 
 use serde::de::Unexpected;
 use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
-use std::result;
 
 /// A BigML status code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,7 +46,7 @@ impl StatusCode {
 }
 
 impl<'de> Deserialize<'de> for StatusCode {
-    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/bigml/src/wait.rs
+++ b/bigml/src/wait.rs
@@ -1,12 +1,10 @@
 //! Utilities for waiting, timeouts and error retries.
 
-use futures::compat::Future01CompatExt;
 use std::cmp::max;
 use std::fmt::Display;
 use std::future::Future;
-use std::result;
 use std::time::{Duration, SystemTime};
-use tokio_timer::Timer;
+use tokio::time::delay_for;
 
 use crate::errors::*;
 
@@ -137,26 +135,26 @@ impl<T, E> From<E> for WaitStatus<T, E> {
 /// or a timeout. Honors `WaitOptions`.
 ///
 /// ```
-/// # extern crate bigml;
-/// # extern crate failure;
 /// # use futures::{FutureExt, TryFutureExt};
 /// # use tokio::prelude::*;
-/// # fn main() {
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), failure::Error> {
 /// use bigml::wait::{wait, WaitOptions, WaitStatus};
 /// use failure::Error;
 ///
 /// let value = wait::<_, failure::Error, _, _>(&WaitOptions::default(), || {
 ///     async { WaitStatus::Finished("my value") }
-/// }).boxed().compat().wait().expect("an error occured while waiting");
+/// }).await?;
 ///
 /// assert_eq!(value, "my value");
+/// #   Ok(())
 /// # }
 /// ```
 ///
 /// If you return `Ok(WaitStatus::Waiting)` instead, this function will wait
 /// some number of seconds, and then try again.
 #[allow(clippy::needless_lifetimes)]
-pub async fn wait<T, E, F, R>(options: &WaitOptions, mut f: F) -> result::Result<T, E>
+pub async fn wait<T, E, F, R>(options: &WaitOptions, mut f: F) -> Result<T, E>
 where
     F: FnMut() -> R,
     R: Future<Output = WaitStatus<T, E>>,
@@ -170,7 +168,6 @@ where
         deadline,
         retry_interval
     );
-    let timer = Timer::default();
     let mut errors_seen = 0;
     loop {
         // Call the function we're waiting on.
@@ -214,7 +211,7 @@ where
 
         // Sleep until our next call.
         let duration = max(Duration::from_secs(MIN_SLEEP_SECS), retry_interval);
-        timer.sleep(duration).compat().await.expect("timer failed");
+        delay_for(duration).await;
 
         // Update retry interval.
         match options.backoff_type {


### PR DESCRIPTION
This is a fairly major update, porting `bigml` and `bigml-parallel` to
use the latest version of `tokio` and various `tokio`-based libraries
such as `reqwest`.

This involves switching to the new `futures::Stream` type, and removing
`fut.compat()` calls throughout the code base. It also involves a lot of
minor API changes.

We also make `bigml::Result<T>` a bit more clever, giving it an optional
`bigml::Result<T, E>` argument, so we no longer need to import
`std::result::Result` everywhere that we need a custom error type to
interface with a third-party API.

All of our dependencies are on current versions, and we've dropped a
number of dependencies that are now handled by `tokio`.