### PR TITLE
bigml-parallel: Allow retrying failed executions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -204,7 +205,7 @@ dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -788,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1414,7 +1415,7 @@ dependencies = [
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+"checksum regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"

--- a/bigml-parallel/Cargo.toml
+++ b/bigml-parallel/Cargo.toml
@@ -23,6 +23,7 @@ env_logger = "0.7"
 failure = "0.1.5"
 futures = "0.3.1"
 log = "0.4"
+regex = "1.3.7"
 serde = { version = "1" }
 serde_json = "1.0"
 # This is pretty heavyweight, but it's easy to set up and nice for users.

--- a/bigml/src/errors.rs
+++ b/bigml/src/errors.rs
@@ -161,6 +161,8 @@ impl Error {
             Error::CouldNotAccessUrl { error, .. } => error.might_be_temporary(),
             Error::CouldNotGetOutput { error, .. } => error.might_be_temporary(),
             Error::CouldNotReadFile { error, .. } => error.might_be_temporary(),
+            // This error occurs when all your BigML "slots" are used and
+            // they're suggesting you upgrade. Backing off may free up slots.
             Error::PaymentRequired { .. } => true,
             _ => false,
         }

--- a/bigml/src/wait.rs
+++ b/bigml/src/wait.rs
@@ -17,7 +17,7 @@ const MIN_SLEEP_SECS: u64 = 4;
 pub enum BackoffType {
     /// Use the same interval for each retry.
     Linear,
-    /// Double the internal after each failure.
+    /// Double the interval after each failure.
     Exponential,
 }
 


### PR DESCRIPTION
The new BigML VPC support shows several types of errors that we haven't
seen before, and many of them are transient errors affecting script
executions. To deal with this, bigml-parallel will need a new mechanism
to retry failed executions.

We do this by adding two new CLI args:

--retry-on=REGEX
--retry-count=N

Here are some sample error strings for `--retry-on`:

// Relatively rare, no confirmation yet from BigML about
// what causes this. But it goes away if we execute another
// script using the same source.
"The source does not contain readable data"
// According the to BigML, this is typically user error
// (often sampling from a dataset with very elements), but
// we've been seeing cases where that is extremely unlikely.
"Sampling, filter, query or generator yielded no rows"
// This goes away if we re-run the execution that reported it.
"An unexpected internal error occurred"