### PR TITLE
Wait longer for temporary errors (such as 504 Gateway Error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- `bigml`: Wait longer for temporary errors (such as 504 Gateway Error) to resolve.
+
 ## 0.6.5 - 2020-05-07
 
 ### Added

--- a/bigml/src/wait.rs
+++ b/bigml/src/wait.rs
@@ -81,8 +81,8 @@ impl Default for WaitOptions {
         Self {
             timeout: None,
             retry_interval: Duration::from_secs(10),
-            backoff_type: BackoffType::Linear,
-            allowed_errors: 2,
+            backoff_type: BackoffType::Exponential,
+            allowed_errors: 6,
         }
     }
 }


### PR DESCRIPTION
because nobody ever said "yeah the best way to recover from my 299 GB source timing out is to start from scratch after trying twice with 10 seconds in between"